### PR TITLE
Colorize zsh prompt

### DIFF
--- a/zsh/main.zsh
+++ b/zsh/main.zsh
@@ -4,7 +4,7 @@ colors
 autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 precmd() { print "" }
-PS1="⟩"
+PS1="%{$fg[cyan]%}⟩%{$reset_color%}"
 RPS1="%{$fg[magenta]%}%20<...<%~%<<%{$reset_color%}"
 
 execute_tmux () {


### PR DESCRIPTION
## Summary
- colorize the primary zsh prompt using cyan to match the right prompt styling

## Testing
- not run (not needed for prompt change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aa3a45dd88320a47e924dd3218603)