### PR TITLE
Fix unwanted Neovim command prompt on startup

### DIFF
--- a/ansible/roles/nvim/tasks/main.yml
+++ b/ansible/roles/nvim/tasks/main.yml
@@ -11,3 +11,8 @@
     dest: "{{ lookup('env','HOME') }}/.config/nvim/"
     mode: "0644"
     directory_mode: "0755"
+
+- name: Clear nvim shada file to fix noice startup prompt
+  ansible.builtin.file:
+    path: "{{ lookup('env', 'HOME') }}/.local/share/nvim/shada/main.shada"
+    state: absent

--- a/nvim/lua/user/noice.lua
+++ b/nvim/lua/user/noice.lua
@@ -1,3 +1,14 @@
+-- Dismiss any pending noice messages on startup to prevent command prompt
+vim.api.nvim_create_autocmd("VimEnter", {
+  callback = function()
+    vim.schedule(function()
+      pcall(function()
+        require("noice").cmd("dismiss")
+      end)
+    end)
+  end,
+})
+
 require("noice").setup({
     lsp = {
     override = {


### PR DESCRIPTION
The noice.nvim command prompt appearing on every Neovim startup is caused by corrupted/stale state in the shada file. Add an ansible task to remove the shada file during bootstrap to ensure a clean startup experience.